### PR TITLE
Fix readme casing of Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var cls = require('continuation-local-storage');
 
 module.exports = function (req, res, next) {
   // pulling from the namespace, and set up per request
-  res.send({value : cls.getNameSpace('namespace').get('whatever')});
+  res.send({value : cls.getNamespace('namespace').get('whatever')});
 
   next();
 };


### PR DESCRIPTION
`res.send({value : cls.getNamespace('namespace').get('whatever')});` had NameSpace (capital s) which makes copy paste fail :)